### PR TITLE
Ad-hoc params instead of just $page and $per_page

### DIFF
--- a/IronWorker.class.php
+++ b/IronWorker.class.php
@@ -179,13 +179,14 @@ class IronWorker extends IronCore{
         return $projects->projects;
     }
 
-    public function getTasks($page = 0, $per_page = 30){
+    public function getTasks($page = 0, $per_page = 30, $additional_params = array()){
         $url = "projects/{$this->project_id}/tasks";
         $this->setJsonHeaders();
         $params = array(
             'page'     => $page,
             'per_page' => $per_page
         );
+        $params = array_merge($additional_params, $params);
         $task = self::json_decode($this->apiCall(self::GET, $url, $params));
         return $task->tasks;
     }


### PR DESCRIPTION
The getTasks method only allowed for a $page and $per_page params.
This allows the other params (filters, from_time, to_time) without
changing the public API in an incompatible way.
