### PR TITLE
Possible change in curl php

### DIFF
--- a/IronWorker.class.php
+++ b/IronWorker.class.php
@@ -297,7 +297,7 @@ class IronWorker extends IronCore
         $url = "projects/{$this->project_id}/codes";
         $post = array(
             "data" => json_encode($sendingData),
-            "file"=>"@".$zipFilename,
+            "file"=> new CURLFile($zipFilename),
         );
         $response = $this->apiCall(self::POST, $url, array(), $post);
         return self::json_decode($response);


### PR DESCRIPTION
I would get this error 

> curl_setopt(): The usage of the @filename API for file uploading is deprecated. Please use the CURLFile class instead

until I did the above.