### PR TITLE
changing filename to match class Runtime

### DIFF
--- a/src/IronWorker.php
+++ b/src/IronWorker.php
@@ -16,7 +16,7 @@ use IronCore\IronCore;
  */
 class IronWorker extends IronCore
 {
-    protected $client_version = '2.0.3';
+    protected $client_version = '2.0.4';
     protected $client_name    = 'iron_worker_php';
     protected $product_name   = 'iron_worker';
     protected $default_values = array(

--- a/src/IronWorkerRuntime.php
+++ b/src/IronWorkerRuntime.php
@@ -1,5 +1,6 @@
 <?php
-namespace IronWorker
+
+namespace IronWorker;
 
 use IronCore\IronCore;
 
@@ -14,7 +15,7 @@ use IronCore\IronCore;
  * @package IronWorker
  * @copyright Feel free to copy, steal, take credit for, or whatever you feel like doing with this code. ;)
  */
-class Runtime extends IronCore {
+class IronWorkerRuntime extends IronCore {
 
   /**
    * getConfig gets the configuration from the input to this worker

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -15,7 +15,7 @@ use IronCore\IronCore;
  * @package IronWorker
  * @copyright Feel free to copy, steal, take credit for, or whatever you feel like doing with this code. ;)
  */
-class IronWorkerRuntime extends IronCore {
+class Runtime extends IronCore {
 
   /**
    * getConfig gets the configuration from the input to this worker


### PR DESCRIPTION
also adding missing `;` in `namespace IronWorker` and updating version to 2.0.4

@thousandsofthem in code, `IronWorker\Runtime::staticMethod()` produces class not found. PHP probably looks for the filename to determine the class name or something lame. this PR renames the filename to `Runtime.php` to be consistent with the `public class Runtime` in that file